### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@lagoni/gh-action-asyncapi-document-bump",
-  "version": "0.3.4",
+  "name": "@lagoni/gh-action-dotnet-bump",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -9950,6 +9950,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lagoni/gh-action-dotnet-bump",
-  "version": "0.3.4",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lagoni/gh-action-dotnet-bump",
-      "version": "0.3.4",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",
@@ -9980,6 +9980,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoni/gh-action-dotnet-bump",
   "description": "GitHub action for bumping version of .NET libraries with semantic release",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jonaslagoni/gh-action-dotnet-bump.git"


### PR DESCRIPTION
Version bump in package.json for release [v0.1.0](https://github.com/jonaslagoni/gh-action-dotnet-bump/releases/tag/v0.1.0)