### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/gh-action-dotnet-bump",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lagoni/gh-action-dotnet-bump",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lagoni/gh-action-dotnet-bump",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",


### PR DESCRIPTION
Version bump in package.json for release [v0.2.1](https://github.com/jonaslagoni/gh-action-dotnet-bump/releases/tag/v0.2.1)